### PR TITLE
feat: get current user implementation

### DIFF
--- a/schema.ts
+++ b/schema.ts
@@ -1,5 +1,5 @@
 import { mysqlTable, serial, text, varchar, timestamp, int } from "drizzle-orm/mysql-core";
-import { sql } from "drizzle-orm";
+import { sql, relations } from "drizzle-orm";
 
 export const users = mysqlTable("users", {
 	id: serial("id").primaryKey(),
@@ -9,9 +9,20 @@ export const users = mysqlTable("users", {
 	createdAt: timestamp("created_at").default(sql`CURRENT_TIMESTAMP`),
 });
 
+export const usersRelations = relations(users, ({ many }) => ({
+	sessions: many(sessions),
+}));
+
 export const sessions = mysqlTable("sessions", {
 	id: serial("id").primaryKey(),
 	token: varchar("token", { length: 255 }).notNull(),
 	userId: int("user_id").notNull().references(() => users.id),
 	createdAt: timestamp("created_at").default(sql`CURRENT_TIMESTAMP`),
 });
+
+export const sessionsRelations = relations(sessions, ({ one }) => ({
+	user: one(users, {
+		fields: [sessions.userId],
+		references: [users.id],
+	}),
+}));

--- a/src/routes/users-route.ts
+++ b/src/routes/users-route.ts
@@ -30,4 +30,18 @@ export const usersRoute = new Elysia({ prefix: "/api" })
             email: t.String(),
             password: t.String()
         })
+    })
+    .post("/users/current", async ({ headers, set }) => {
+        try {
+            const authHeader = headers['authorization'];
+            if (!authHeader || !authHeader.startsWith('Bearer ')) {
+                throw new Error("unautorized");
+            }
+
+            const token = authHeader.split(' ')[1];
+            return await userService.getCurrentUser(token);
+        } catch (error: any) {
+            set.status = 401;
+            return { error: error.message };
+        }
     });

--- a/src/services/user-service.ts
+++ b/src/services/user-service.ts
@@ -56,4 +56,21 @@ export class UserService {
 
         return { data: token };
     }
+
+    async getCurrentUser(token: string) {
+        // Find session and join with user
+        const sessionWithUser = await db.query.sessions.findFirst({
+            where: eq(sessions.token, token),
+            with: {
+                user: true
+            }
+        });
+
+        if (!sessionWithUser || !sessionWithUser.user) {
+            throw new Error("unautorized");
+        }
+
+        const { password, ...userWithoutPassword } = sessionWithUser.user;
+        return { data: userWithoutPassword };
+    }
 }


### PR DESCRIPTION
This PR implements the API to fetch current user profile using Bearer token authentication, as defined in issue #7.